### PR TITLE
Add undo/redo support

### DIFF
--- a/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
+++ b/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
@@ -2,6 +2,7 @@ tool
 extends Control
 
 var interface : EditorInterface
+var undo_redo : UndoRedo
 
 var selected_nodes : = []
 
@@ -31,11 +32,21 @@ func _input(event: InputEvent) -> void:
 func selected_anchor(which : int) -> void:
 	if selected_nodes:
 		for i in selected_nodes:
+			undo_redo.create_action("Change Anchors and Margins" if !modifier else "Change Anchors")
+			undo_redo.add_undo_property(i, "anchor_bottom", i.anchor_bottom)
+			undo_redo.add_undo_property(i, "anchor_top", i.anchor_top)
+			undo_redo.add_undo_property(i, "anchor_left", i.anchor_left)
+			undo_redo.add_undo_property(i, "anchor_right", i.anchor_right)
+			undo_redo.add_undo_property(i, "margin_bottom", i.margin_bottom)
+			undo_redo.add_undo_property(i, "margin_top", i.margin_top)
+			undo_redo.add_undo_property(i, "margin_left", i.margin_left)
+			undo_redo.add_undo_property(i, "margin_right", i.margin_right)
 			if !modifier:
-				i.set_anchors_and_margins_preset(which, panel.layout_preset_mode_selected, 0)
+				undo_redo.add_do_method(i, "set_anchors_and_margins_preset", which, panel.layout_preset_mode_selected, 0)
 			else:
-				i.set_anchors_preset(which)
-				
+				undo_redo.add_do_method(i, "set_anchors_preset", which)
+			undo_redo.commit_action()
+
 
 
 func on_main_screen_changed(which : String) -> void:

--- a/addons/epic-anchors/plugin.gd
+++ b/addons/epic-anchors/plugin.gd
@@ -12,6 +12,7 @@ func get_plugin_name() -> String:
 func _enter_tree():
 	anchors_instance = preload("res://addons/epic-anchors/AnchorsPanel/Anchors.tscn").instance()
 	anchors_instance.interface = get_editor_interface()
+	anchors_instance.undo_redo = get_undo_redo()
 	connect("main_screen_changed", anchors_instance, "on_main_screen_changed")
 	
 func _process(delta: float) -> void:


### PR DESCRIPTION
Thank you for this nice plugin.

This patch adds undo/redo support which is quite useful if you make a mistake such as setting the anchors/margins of the wrong node.

Currently the command names (i.e. "Change Anchors and Margins" and "Change Anchors") are hard-coded in English. Even though the editor has translations for these strings, I could not figure out how to use these translations from the editor plugin.

cc @lentsius-bark

Built-in anchor panel undo/redo:
![has-undo-redo](https://user-images.githubusercontent.com/3696783/142713880-ea514f8a-d47b-4a24-8921-ab58f9e834bb.gif)

Before patch:
![no-undo-redo](https://user-images.githubusercontent.com/3696783/142713881-9587f6fc-6d19-446b-be83-cac747295c7a.gif)

After patch:
![undo-redo-added](https://user-images.githubusercontent.com/3696783/142713882-ad4f7c96-fd41-4fb4-a673-93045912f043.gif)
