### PR TITLE
Changed the project setting path to be Epic Anchors

### DIFF
--- a/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
+++ b/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
@@ -25,17 +25,17 @@ func _ready() -> void:
 
 
 func setup_project_setting_variables() -> void:
-	if ProjectSettings.has_setting("global/use_editor_theme_color"):
-		use_editor_theme_color = ProjectSettings.get_setting("global/use_editor_theme_color")
+	if ProjectSettings.has_setting("epic_anchors/use_editor_theme_color"):
+		use_editor_theme_color = ProjectSettings.get_setting("epic_anchors/use_editor_theme_color")
 	else:
-		ProjectSettings.set_setting("global/use_editor_theme_color", use_editor_theme_color)
-		ProjectSettings.set_initial_value("global/use_editor_theme_color", use_editor_theme_color)
+		ProjectSettings.set_setting("epic_anchors/use_editor_theme_color", use_editor_theme_color)
+		ProjectSettings.set_initial_value("epic_anchors/use_editor_theme_color", use_editor_theme_color)
 	
-	if ProjectSettings.has_setting("global/custom_hover_color"):
-		custom_hover_color = ProjectSettings.get_setting("global/custom_hover_color")
+	if ProjectSettings.has_setting("epic_anchors/custom_hover_color"):
+		custom_hover_color = ProjectSettings.get_setting("epic_anchors/custom_hover_color")
 	else:
-		ProjectSettings.set_setting("global/custom_hover_color", custom_hover_color)
-		ProjectSettings.set_initial_value("global/custom_hover_color", custom_hover_color)
+		ProjectSettings.set_setting("epic_anchors/custom_hover_color", custom_hover_color)
+		ProjectSettings.set_initial_value("epic_anchors/custom_hover_color", custom_hover_color)
 	
 
 

--- a/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
+++ b/addons/epic-anchors/AnchorsPanel/AnchorsMain.gd
@@ -28,14 +28,14 @@ func setup_project_setting_variables() -> void:
 	if ProjectSettings.has_setting("global/use_editor_theme_color"):
 		use_editor_theme_color = ProjectSettings.get_setting("global/use_editor_theme_color")
 	else:
-		ProjectSettings.set_initial_value("global/use_editor_theme_color", use_editor_theme_color)
 		ProjectSettings.set_setting("global/use_editor_theme_color", use_editor_theme_color)
+		ProjectSettings.set_initial_value("global/use_editor_theme_color", use_editor_theme_color)
 	
 	if ProjectSettings.has_setting("global/custom_hover_color"):
 		custom_hover_color = ProjectSettings.get_setting("global/custom_hover_color")
 	else:
-		ProjectSettings.set_initial_value("global/custom_hover_color", custom_hover_color)
 		ProjectSettings.set_setting("global/custom_hover_color", custom_hover_color)
+		ProjectSettings.set_initial_value("global/custom_hover_color", custom_hover_color)
 	
 
 


### PR DESCRIPTION
Didn't think of this when I first made it, but this just makes more sense. 

Also the initial values weren't working, flipped them around and now they are. Not necessary but i like when i can revert back to default